### PR TITLE
Update matrix.md

### DIFF
--- a/networking/matrix.md
+++ b/networking/matrix.md
@@ -22,7 +22,7 @@ Matrix is kind of like a federated IRC system and [Riot](https://about.riot.im) 
 - [Matrix GSOC ideas](https://github.com/matrix-org/GSoC/blob/master/IDEAS.md#what-is-matrix)
 - [Matrix IRCd](https://github.com/matrix-org/matrix-ircd)
 - [Riot Web](https://github.com/vector-im/riot-web) - Web client for Matrix.
-- [Ruma](https://github.com/ruma/ruma) - Matrix homeserver written in Rust.
+- [Ruma](https://github.com/ruma/homeserver) - Matrix homeserver written in Rust. (discontinued)
 - [Nheko](https://github.com/mujx/nheko) - Native desktop client for Matrix.
 - [Client-Server API](https://matrix.org/docs/spec/client_server/r0.3.0.html)
 - [Matrix Blog](https://matrix.org/blog/posts/)


### PR DESCRIPTION
### Summary

Update entry for the Matrix homeserver Ruma.

### Changes

- Update link
- Note that the homeserver (though not the project as a whole) is discontinued

### Notes

Maybe adding an entry for the libraries that now live in the location previously used by the homeserver would be useful :shrug:

I'm only filing this because I found the wrong entry via https://grep.app and thought I could quickly fix it.