### PR TITLE
Added alternative for broken link

### DIFF
--- a/databases/sql/sql.md
+++ b/databases/sql/sql.md
@@ -15,7 +15,7 @@
 - [Learn Modern SQL with PostgreSQL](https://www.masterywithsql.com/) ([HN](https://news.ycombinator.com/item?id=20260292))
 - [PartiQL](https://partiql.org/) - SQL-compatible access to relational, semi-structured, and nested data.
 - [BlazingSQL](https://github.com/BlazingDB/pyBlazing) - Lightweight, GPU accelerated, SQL engine built on RAPIDS.
-- [10 Ways to Tweak Slow SQL Queries](http://www.helenanderson.co.nz/sql-query-tweaks/) ([HN](https://news.ycombinator.com/item?id=20855441))
+- [10 Ways to Tweak Slow SQL Queries](http://www.helenanderson.co.nz/sql-query-tweaks/) ([HN](https://news.ycombinator.com/item?id=20855441)) [alternative: How to Fix Slow SQL Queries](https://www.databasestar.com/slow-sql/)
 - [osquery](https://github.com/osquery/osquery) - SQL powered operating system instrumentation, monitoring, and analytics.
 - [SQL queries don't start with SELECT (2019)](https://jvns.ca/blog/2019/10/03/sql-queries-don-t-start-with-select/)
 - [OctoSQL](https://github.com/cube2222/octosql) - Query tool that allows you to join, analyse and transform data from multiple databases and file formats using SQL.


### PR DESCRIPTION
The link to a page was broken and an alternative similar link was added.

### Summary
A link to an article on fixing slow SQL queries is broken. I've left the original link there (and the link to the HackerNews page), and added an alternative link to a similar article on fixing slow SQL queries.

