### PR TITLE
Tiny - remove a duplicate link to Solid.js

### DIFF
--- a/programming-languages/javascript/js-libraries/js-libraries.md
+++ b/programming-languages/javascript/js-libraries/js-libraries.md
@@ -10,7 +10,6 @@
 - [Umi](https://github.com/umijs/umi) - Pluggable enterprise-level react application framework.
 - [Vue.js](https://vuejs.org/) - Progressive JavaScript Framework.
 - [Mithril](https://mithril.js.org/) - Modern client-side Javascript framework for building Single Page Applications. ([HN](https://news.ycombinator.com/item?id=25800754))
-- [Solid](https://github.com/ryansolid/solid) - Declarative, efficient, and flexible JavaScript library for building user interfaces.
 - [Neutrino dev](https://github.com/mozilla-neutrino/neutrino-dev)
 - [Alpine.js](https://github.com/alpinejs/alpine) - Rugged, minimal framework for composing JavaScript behavior in your markup. ([Awesome Alpine](https://github.com/alpine-collective/awesome)) ([HN](https://news.ycombinator.com/item?id=27707887))
 - [After.js](https://github.com/jaredpalmer/after.js) - Next.js-like framework for server-rendered React apps built with React Router 4.


### PR DESCRIPTION
Side note, I get why you promoted the link to the top of the list - I am very excited about Solid too.
