### PR TITLE
Remove duplicate item in zig.md

### DIFF
--- a/docs/programming-languages/zig/zig.md
+++ b/docs/programming-languages/zig/zig.md
@@ -152,7 +152,6 @@ title: Zig
 - [Mach engine & core examples](https://github.com/hexops/mach-examples)
 - [Ziglibc: Sweeping out the rug from underneath C - Jonathan Marler (2022)](https://www.youtube.com/watch?v=1N85yU6RMcY)
 - [Zig Is Self-Hosted Now, What's Next? (2022)](https://kristoff.it/blog/zig-self-hosted-now-what/) ([Lobsters](https://lobste.rs/s/csax21/zig_is_self_hosted_now_what_s_next)) ([HN](https://news.ycombinator.com/item?id=33331549))
-- [Ziglibc: Sweeping out the rug from underneath C - Jonathan Marler (2022)](https://www.youtube.com/watch?v=1N85yU6RMcY)
 - [Zig's I/O and Concurrency Story - King Protty (2022)](https://www.youtube.com/watch?v=Ul8OO4vQMTw)
 - [Distributed Zig with Elixir and Zigler - Riccardo Binetti (2022)](https://www.youtube.com/watch?v=l75KLCJaGxw)
 - [A minimal RocksDB example with Zig (2022)](https://notes.eatonphil.com/zigrocks.html)


### PR DESCRIPTION
<!-- Check readme/contributing docs. Reference related issues: Fix #00, Ref #00 -->

### Summary
Remove a duplicate item in zig.md. The removed link is just 1 line above.
