### PR TITLE
Add RunJS

### DIFF
--- a/docs/programming-languages/typescript/typescript.md
+++ b/docs/programming-languages/typescript/typescript.md
@@ -332,6 +332,7 @@ Run TS with [Bun](../javascript/bun.md) and deploy [HTTP](../../networking/http.
 - [Acorn TypeScript](https://github.com/TyrealHu/acorn-typescript) - Alternative, TypeScript parser.
 - [Typescript Tools That Make You Productive (2023)](https://www.youtube.com/watch?v=WJeD3DKlWT4)
 - [TypeScript neat tricks](https://github.com/typed-rocks/typescript)
+- [RunJS](https://runjs.app/typescript-playground/) - JavaScript/TypeScript Playground.
 
 ## Images
 


### PR DESCRIPTION
### Summary

RunJS is a Javascript/TypeScript playground for desktop - available for Mac, Windows and Linux.

https://runjs.app/typescript-playground/